### PR TITLE
Only use filter on TarFile.extractall if on python 3.11.4 or later.

### DIFF
--- a/src/safe_extractor.py
+++ b/src/safe_extractor.py
@@ -126,6 +126,7 @@ def safe_extract(
                     if sys.version_info.major == 3 and sys.version_info.minor >= 11 and sys.version_info.patch >= 4:
                         archive.extractall(
                             path=extract_path, members=permitted_members, filter="data"
+                        )
                     else:
                         archive.extractall(path=extract_path, members=permitted_members)
                 _delete_remaining_symlinks(extract_path, max_size)

--- a/src/safe_extractor.py
+++ b/src/safe_extractor.py
@@ -123,7 +123,11 @@ def safe_extract(
                         archive.getmembers(), extract_path
                     )
                     # filter keyword is only supported in Python 3.11.4 and above.
-                    if sys.version_info.major == 3 and sys.version_info.minor >= 11 and sys.version_info.patch >= 4:
+                    if (
+                        sys.version_info.major == 3
+                        and sys.version_info.minor >= 11
+                        and sys.version_info.patch >= 4
+                    ):
                         archive.extractall(
                             path=extract_path, members=permitted_members, filter="data"
                         )

--- a/src/safe_extractor.py
+++ b/src/safe_extractor.py
@@ -29,6 +29,7 @@ from pathlib import Path
 import io
 import logging
 import os
+import sys
 import tarfile
 import zipfile
 
@@ -121,9 +122,12 @@ def safe_extract(
                     permitted_members = _safe_tar_members(
                         archive.getmembers(), extract_path
                     )
-                    archive.extractall(
-                        path=extract_path, members=permitted_members, filter="data"
-                    )
+                    # filter keyword is only supported in Python 3.11.4 and above.
+                    if sys.version_info.major == 3 and sys.version_info.minor >= 11 and sys.version_info.patch >= 4:
+                        archive.extractall(
+                            path=extract_path, members=permitted_members, filter="data"
+                    else:
+                        archive.extractall(path=extract_path, members=permitted_members)
                 _delete_remaining_symlinks(extract_path, max_size)
             except tarfile.TarError as err:
                 raise ValueError("Bad tar file") from err


### PR DESCRIPTION
It turns out that the filter keyword was added in a patch update (grrrr) and so isn't supported on the Python version on the host.