### PR TITLE
Add missing bracket

### DIFF
--- a/src/safe_extractor.py
+++ b/src/safe_extractor.py
@@ -126,6 +126,7 @@ def safe_extract(
                     if sys.version_info.major == 3 and sys.version_info.minor >= 11 and sys.version_info.patch >= 4:
                         archive.extractall(
                             path=extract_path, members=permitted_members, filter="data"
+                        )
                     else:
                         archive.extractall(path=extract_path, members=permitted_members)
                 _delete_remaining_symlinks(extract_path, max_size)

--- a/src/safe_extractor.py
+++ b/src/safe_extractor.py
@@ -123,7 +123,11 @@ def safe_extract(
                         archive.getmembers(), extract_path
                     )
                     # filter keyword is only supported in Python 3.11.4 and above.
-                    if sys.version_info.major == 3 and sys.version_info.minor >= 11 and sys.version_info.patch >= 4:
+                    if (
+                        sys.version_info.major == 3
+                        and sys.version_info.minor >= 11
+                        and sys.version_info.patch >= 4
+                    ):
                         archive.extractall(
                             path=extract_path, members=permitted_members, filter="data"
                         )


### PR DESCRIPTION
> It turns out that the filter keyword was added in a patch update (grrrr) and so isn't supported on the Python version on the host.
