### PR TITLE
Allow any origin to access returned URL

### DIFF
--- a/src/tmpweb.py
+++ b/src/tmpweb.py
@@ -175,6 +175,7 @@ def create_site(environ):
         "headers": [
             ("Content-Type", "text/plain"),
             ("Content-Length", str(len(url_bytes))),
+            ("Access-Control-Allow-Origin", "*"),
         ],
         "data": [url_bytes],
     }


### PR DESCRIPTION
Its a public API, so we want it to be accessible.